### PR TITLE
with python3.6 tag.needed does not have the attribute decode

### DIFF
--- a/list_missing_libs.py
+++ b/list_missing_libs.py
@@ -143,7 +143,7 @@ class BrokenFinder():
                                                  elffile)
 
                         for tag in section.iter_tags('DT_NEEDED'):
-                            self.lib2required_by[bytes2str(tag.needed)].append(sofile)
+                            self.lib2required_by[tag.needed].append(sofile)
                         break # there should only be one dyanmic section
 
                 except ELFError:


### PR DESCRIPTION
as per title. patch tested.

the error without this patch was:
```
Traceback (most recent call last):
  File "list_missing_libs.py", line 203, in <module>
    htmlreport = b.report()
  File "list_missing_libs.py", line 173, in report
    missing_libs, broken_packages = self.check()
  File "list_missing_libs.py", line 157, in check
    self.collect_needed(lib_or_bin)
  File "list_missing_libs.py", line 146, in collect_needed
    self.lib2required_by[bytes2str(tag.needed)].append(sofile)
  File "/usr/lib/python3.6/site-packages/elftools/common/py3compat.py", line 22, in bytes2str
    def bytes2str(b): return b.decode('latin-1')
AttributeError: 'str' object has no attribute 'decode'
```